### PR TITLE
Add energy NFT CSV template and regression tests

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,16 @@
+# Energy NFT Events Template
+
+The `nrg_nft_events_template.csv` file defines the expected format for energy-related NFT event logs.
+
+## Columns
+
+The CSV contains six columns:
+
+1. `timestamp` – ISO‑8601 timestamp for the event.
+2. `id` – Unique numeric identifier for the event.
+3. `energy_kwh` – Energy produced in kilowatt-hours.
+4. `co2_kg` – Associated CO₂ emissions in kilograms.
+5. `miner` – Name or ID of the miner responsible.
+6. `proof` – Reference hash or proof string.
+
+Sample rows are included in the template for guidance.

--- a/data/nrg_nft_events_template.csv
+++ b/data/nrg_nft_events_template.csv
@@ -1,0 +1,3 @@
+timestamp,id,energy_kwh,co2_kg,miner,proof
+2024-01-01T00:00:00Z,1,10.5,2.3,minerA,proof123
+2024-01-02T12:30:00Z,2,8.0,1.9,minerB,proof456

--- a/tests/test_nrg_nft_events_template.py
+++ b/tests/test_nrg_nft_events_template.py
@@ -1,0 +1,15 @@
+import csv
+from pathlib import Path
+
+REQUIRED_COLUMNS = ["timestamp", "id", "energy_kwh", "co2_kg", "miner", "proof"]
+
+
+def test_template_has_required_columns():
+    csv_path = Path(__file__).resolve().parents[1] / "data" / "nrg_nft_events_template.csv"
+    with csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == REQUIRED_COLUMNS
+        rows = list(reader)
+    assert rows, "Template should contain at least one sample row"
+    for row in rows:
+        assert set(row.keys()) == set(REQUIRED_COLUMNS)


### PR DESCRIPTION
## Summary
- add `nrg_nft_events_template.csv` with six-column header and sample entries
- document CSV format in `data/README.md`
- add regression test validating required CSV columns

## Testing
- `pytest -q`
- `codex-sig verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a7b1e36648330bca2cc7a6e0fc043