### PR TITLE
Add WebSocket demo servers with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # terra-nature-v2.4
 Dashboards zur CO₂-Tracking, Terra Nature selbst ist ein Konzept zur CO₂-Kompensation mit technischen und ökonomischen Modellen.
+
+## Demo WebSocket Servers
+
+Zwei einfache Demo-Server erzeugen zufällige NRG-Event-Payloads.
+
+### Node.js
+- Abhängigkeiten installieren: `npm install`
+- Server starten: `node tools/ws_demo_server.js`
+
+### Python
+- Abhängigkeiten installieren: `pip install -r requirements.txt`
+- Server starten: `python tools/ws_demo_server.py`
+
+Jede Verbindung erhält Nachrichten wie `{"type": "NRG", "value": 0.42, "id": "..."}`.
+
+## Tests
+
+Unit-Tests für beide Implementierungen ausführen:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "terra-nature-v2.4",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test tests/test_ws_demo_server_js.js && pytest"
+  },
+  "dependencies": {
+    "ws": "^8.17.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+websockets
+pytest

--- a/tests/test_ws_demo_server_js.js
+++ b/tests/test_ws_demo_server_js.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { once } = require('events');
+const WebSocket = require('ws');
+const { createServer } = require('../tools/ws_demo_server.js');
+const test = require('node:test');
+
+test('ws_demo_server.js emits NRG payload', async () => {
+  const server = createServer({ port: 0 });
+  await once(server, 'listening');
+  const port = server.address().port;
+
+  const ws = new WebSocket(`ws://localhost:${port}`);
+  const [message] = await once(ws, 'message');
+  ws.close();
+  server.close();
+
+  const payload = JSON.parse(message);
+  assert.equal(payload.type, 'NRG');
+  assert.equal(typeof payload.value, 'number');
+});

--- a/tests/test_ws_demo_server_py.py
+++ b/tests/test_ws_demo_server_py.py
@@ -1,0 +1,22 @@
+import asyncio
+import json
+
+import pytest
+import websockets
+
+import tools.ws_demo_server as ws_demo_server
+
+
+@pytest.mark.asyncio
+async def test_ws_demo_server_py():
+    server = await ws_demo_server.start_server(port=0)
+    port = server.sockets[0].getsockname()[1]
+
+    async with websockets.connect(f"ws://localhost:{port}") as ws:
+        message = await ws.recv()
+        payload = json.loads(message)
+        assert payload["type"] == "NRG"
+        assert isinstance(payload["value"], float)
+
+    server.close()
+    await server.wait_closed()

--- a/tools/ws_demo_server.js
+++ b/tools/ws_demo_server.js
@@ -1,0 +1,28 @@
+const WebSocket = require('ws');
+const crypto = require('crypto');
+
+function randomPayload() {
+  return JSON.stringify({
+    type: 'NRG',
+    value: Math.random(),
+    id: crypto.randomUUID()
+  });
+}
+
+function createServer({ port = 8765 } = {}) {
+  const wss = new WebSocket.Server({ port });
+  wss.on('connection', (ws) => {
+    ws.send(randomPayload());
+    const interval = setInterval(() => ws.send(randomPayload()), 1000);
+    ws.on('close', () => clearInterval(interval));
+  });
+  return wss;
+}
+
+if (require.main === module) {
+  const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 8765;
+  createServer({ port });
+  console.log(`WS demo server running on ws://localhost:${port}`);
+}
+
+module.exports = { createServer };

--- a/tools/ws_demo_server.py
+++ b/tools/ws_demo_server.py
@@ -1,0 +1,39 @@
+import asyncio
+import json
+import os
+import random
+import uuid
+import websockets
+
+
+def random_payload():
+    return json.dumps({
+        "type": "NRG",
+        "value": random.random(),
+        "id": str(uuid.uuid4()),
+    })
+
+
+async def handler(websocket):
+    try:
+        await websocket.send(random_payload())
+        while True:
+            await asyncio.sleep(1)
+            await websocket.send(random_payload())
+    except websockets.ConnectionClosed:
+        pass
+
+
+async def start_server(host="localhost", port=8765):
+    return await websockets.serve(handler, host, port)
+
+
+async def serve(host="localhost", port=8765):
+    async with await start_server(host, port):
+        print(f"WS demo server running on ws://{host}:{port}")
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8765))
+    asyncio.run(serve(port=port))


### PR DESCRIPTION
## Summary
- add Node.js and Python WebSocket demo servers that emit random NRG event payloads
- document how to run the servers and install dependencies
- include minimal unit tests for both demo servers

## Testing
- `npm test` *(fails: Cannot find module 'ws')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `npx @sourcegraph/codex-scripts verify` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a7b1f8ca4833098959eb7edc1d178