### PR TITLE
Organize demo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # terra-nature-v2.4
+
 Dashboards zur CO₂-Tracking, Terra Nature selbst ist ein Konzept zur CO₂-Kompensation mit technischen und ökonomischen Modellen.
+
+## Quick Start
+
+1. Installiere entweder Python 3 oder Node.js.
+2. Starte den Demo-Server:
+   - Python: `python tools/ws_demo_server.py`
+   - Node: `node tools/ws_demo_server.js`
+3. Öffne `http://localhost:8000/dashboard.html` im Browser.
+
+## Verzeichnisstruktur
+
+- `data/nrg_nft_events_template.csv` – Vorlage für NFT-Energiedaten.
+- `public/terra_brand.css` – Terra Nature CSS-Branding.
+- `public/dashboard.html` – Beispiel-Dashboard, das das CSS nutzt.
+- `tools/ws_demo_server.*` – einfache Server zum lokalen Testen.

--- a/data/nrg_nft_events_template.csv
+++ b/data/nrg_nft_events_template.csv
@@ -1,0 +1,3 @@
+event_id,event_type,energy_kwh,timestamp
+1,mint,100,2024-01-01T00:00:00Z
+2,transfer,50,2024-01-02T12:00:00Z

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Terra Nature Dashboard</title>
+  <link rel="stylesheet" href="terra_brand.css">
+</head>
+<body>
+  <header>
+    <h1>Terra Nature Dashboard</h1>
+  </header>
+  <main>
+    <p>Welcome to the Terra Nature dashboard.</p>
+  </main>
+</body>
+</html>

--- a/public/terra_brand.css
+++ b/public/terra_brand.css
@@ -1,0 +1,10 @@
+body {
+  font-family: sans-serif;
+  background-color: #f0f4f8;
+  color: #333;
+}
+header {
+  background-color: #2a9d8f;
+  color: white;
+  padding: 1rem;
+}

--- a/tools/ws_demo_server.js
+++ b/tools/ws_demo_server.js
@@ -1,0 +1,27 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.join(__dirname, '..', 'public');
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(publicDir, req.url === '/' ? 'dashboard.html' : req.url);
+  const ext = path.extname(filePath);
+  let contentType = 'text/html';
+  if (ext === '.css') contentType = 'text/css';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+});
+
+const port = 8000;
+server.listen(port, () => {
+  console.log(`Serving ${publicDir} on http://localhost:${port}`);
+});

--- a/tools/ws_demo_server.py
+++ b/tools/ws_demo_server.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import pathlib
+
+PUBLIC_DIR = pathlib.Path(__file__).resolve().parent.parent / 'public'
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(PUBLIC_DIR), **kwargs)
+
+if __name__ == '__main__':
+    port = 8000
+    with socketserver.TCPServer(('', port), Handler) as httpd:
+        print(f'Serving {PUBLIC_DIR} at http://localhost:{port}')
+        httpd.serve_forever()


### PR DESCRIPTION
## Summary
- move generated CSV, demo servers, and branding assets into dedicated data/, tools/, and public/ folders
- add basic dashboard HTML and style sheet referencing new asset paths
- document quick start and asset locations in README

## Testing
- `pytest`
- `codex verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a7b23712083309d47e1753152e0ee