### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Terra-Nature-powered-by-terraloft/terra-nature-v2.4/security/code-scanning/2](https://github.com/Terra-Nature-powered-by-terraloft/terra-nature-v2.4/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `build` job in `.github/workflows/npm-publish-github-packages.yml`. This block should specify the least privilege required for the job. Since the `build` job only checks out code, sets up Node, installs dependencies, and runs tests, it only needs read access to repository contents. Therefore, add `permissions: contents: read` under the `build` job, at the same indentation level as `runs-on`. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
