### PR TITLE
Add agent instruction helper and improve test tooling

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,2 @@
 #!/bin/sh
-npx --no commitlint --edit "$1"
+npx commitlint --edit "$1"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ Dashboards zur CO₂-Tracking, Terra Nature selbst ist ein Konzept zur CO₂-Kom
 
 Zwei einfache Demo-Server erzeugen zufällige NRG-Event-Payloads.
 
+## Agentenmodus
+
+Um eventuelle Arbeitsanweisungen in `AGENTS.md`-Dateien zu prüfen, kann das Hilfsskript `tools/agentenmodus.py` ausgeführt werden:
+
+```bash
+python tools/agentenmodus.py
+```
+
+Es durchsucht das Repository (ausgenommen Caches und `node_modules`) und gibt alle gefundenen Instruktionen aus.
+
 ### Node.js
 - Abhängigkeiten installieren: `npm install`
 - Server starten: `node tools/ws_demo_server.js`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --test tests/test_ws_demo_server_js.js && PYTHONPATH=. pytest",
+    "test": "python tools/run_all_tests.py",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/tools/agentenmodus.py
+++ b/tools/agentenmodus.py
@@ -1,0 +1,51 @@
+"""Hilfsskript zum Auffinden von AGENTS.md-Anweisungen im Repository."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Iterator
+
+IGNORED_DIRECTORIES = {".git", "node_modules", "__pycache__"}
+
+
+def find_agents(root: Path) -> Iterator[Path]:
+    """Yield all AGENTS.md files below ``root`` sorted by their relative path."""
+    for path in sorted(root.iterdir() if root.is_dir() else []):
+        if path.name in IGNORED_DIRECTORIES:
+            continue
+        if path.is_file() and path.name == "AGENTS.md":
+            yield path
+        elif path.is_dir():
+            yield from find_agents(path)
+
+
+def print_agent_instructions(agent_paths: Iterable[Path], root: Path) -> None:
+    """Druckt die Inhalte der gefundenen AGENTS.md-Dateien."""
+    printed_any = False
+    for path in sorted(agent_paths, key=lambda p: p.relative_to(root).as_posix()):
+        printed_any = True
+        relative = path.relative_to(root)
+        print(f"# {relative}")
+        print(path.read_text(encoding="utf-8").strip())
+        print()
+
+    if not printed_any:
+        print("Keine AGENTS.md-Dateien gefunden. Es liegen keine zusätzlichen Agentenhinweise vor.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Repository-Wurzel, in der nach AGENTS.md-Dateien gesucht wird.",
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    print_agent_instructions(find_agents(root), root)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -1,0 +1,32 @@
+"""Hilfsskript zum Ausführen der Node.js- und Python-Test-Suites ohne zusätzliche Argumente."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_node_tests() -> None:
+    subprocess.run(["node", "--test", "tests/test_ws_demo_server_js.js"], check=True, cwd=ROOT)
+
+
+def run_py_tests() -> None:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    pythonpath_parts = [str(ROOT)]
+    if existing:
+        pythonpath_parts.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+    subprocess.run([sys.executable, "-m", "pytest"], check=True, cwd=ROOT, env=env)
+
+
+def main() -> None:
+    run_node_tests()
+    run_py_tests()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python helper to list AGENTS.md instructions and document its usage
- wrap project tests in a single script so lint-staged hooks ignore extra file arguments
- fix the commit-msg hook to call commitlint with the correct flag

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2fe9c7a6483308aa8bd41a2eae509