### PR TITLE
feat: add TerraBrand styling and dashboard tests

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,50 @@
+import type { ReactNode } from 'react';
+
+const TERRABRAND_STYLES = `
+  @font-face {
+    font-family: "TerraBrand Sans";
+    src: local("Inter"), local("Arial"), local("Helvetica");
+    font-display: swap;
+  }
+
+  @font-face {
+    font-family: "TerraBrand Serif";
+    src: local("Georgia"), local("Times New Roman"), serif;
+    font-display: swap;
+  }
+
+  :root {
+    --terra-brand-font-sans: "TerraBrand Sans", "Inter", "system-ui", sans-serif;
+    --terra-brand-font-serif: "TerraBrand Serif", "Georgia", "Times New Roman", serif;
+  }
+
+  body {
+    font-family: var(--terra-brand-font-sans);
+    margin: 0;
+    background-color: #f6f7f9;
+    color: #111827;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--terra-brand-font-sans);
+  }
+`;
+
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <html lang="en">
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: TERRABRAND_STYLES }} />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/components/TerraNatureDashboardV2Live.tsx
+++ b/components/TerraNatureDashboardV2Live.tsx
@@ -21,11 +21,11 @@ export default function TerraNatureDashboardV2Live() {
   };
 
   return (
-    <div style={{ 
-      maxWidth: '1200px', 
-      margin: '0 auto', 
+    <div style={{
+      maxWidth: '1200px',
+      margin: '0 auto',
       padding: '20px',
-      fontFamily: 'system-ui, -apple-system, sans-serif'
+      fontFamily: 'var(--terra-brand-font-sans, "TerraBrand Sans", "Inter", "system-ui", "sans-serif")'
     }}>
       {/* Header */}
       <div style={{ 

--- a/tests/test_dashboard_integrations.js
+++ b/tests/test_dashboard_integrations.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { once } = require('events');
+const WebSocket = require('ws');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..');
+
+function readProjectFile(relativePath) {
+  const absolutePath = path.join(ROOT, relativePath);
+  return fs.readFileSync(absolutePath, 'utf8');
+}
+
+test('Terra Nature dashboard references TerraBrand fonts', () => {
+  const layoutContent = readProjectFile('app/layout.tsx');
+  const componentContent = readProjectFile('components/TerraNatureDashboardV2Live.tsx');
+
+  assert(/TerraBrand\s+Sans/.test(layoutContent), 'Layout should declare TerraBrand Sans font');
+  assert(/TerraBrand\s+Serif/.test(layoutContent), 'Layout should declare TerraBrand Serif font');
+  assert(/TerraBrand\s+Sans/.test(componentContent), 'Dashboard component should use TerraBrand Sans font family');
+});
+
+test('NRG NFT template CSV can be ingested', () => {
+  const csvContent = readProjectFile('data/nrg_nft_events_template.csv').trim();
+  const [headerLine, ...rows] = csvContent.split(/\r?\n/);
+  const headers = headerLine.split(',');
+
+  assert.deepStrictEqual(headers, ['timestamp', 'id', 'energy_kwh', 'co2_kg', 'miner', 'proof']);
+  assert(rows.length > 0, 'CSV should include at least one data row');
+
+  const parsedRows = rows.map((row) => {
+    const values = row.split(',');
+    return headers.reduce((record, header, index) => {
+      record[header] = values[index];
+      return record;
+    }, {});
+  });
+
+  for (const record of parsedRows) {
+    assert.ok(record.timestamp, 'timestamp should be present');
+    assert.ok(record.id, 'id should be present');
+    assert.ok(record.miner, 'miner should be present');
+    assert.ok(record.proof, 'proof should be present');
+    assert(!Number.isNaN(Number.parseFloat(record.energy_kwh)), 'energy_kwh should parse to a number');
+    assert(!Number.isNaN(Number.parseFloat(record.co2_kg)), 'co2_kg should parse to a number');
+  }
+});
+
+test('Demo WebSocket server streams Terra Nature events', async () => {
+  const { createServer } = require('../tools/ws_demo_server.js');
+
+  const server = createServer({ port: 0 });
+  await once(server, 'listening');
+  const port = server.address().port;
+
+  const ws = new WebSocket(`ws://localhost:${port}`);
+  const [firstMessage] = await once(ws, 'message');
+  const [secondMessage] = await once(ws, 'message');
+  ws.close();
+  server.close();
+
+  const firstPayload = JSON.parse(firstMessage);
+  const secondPayload = JSON.parse(secondMessage);
+
+  assert.equal(firstPayload.type, 'NRG');
+  assert.equal(typeof firstPayload.value, 'number');
+  assert.ok(firstPayload.id, 'payload should include id field');
+
+  assert.equal(secondPayload.type, 'NRG');
+  assert.equal(typeof secondPayload.value, 'number');
+  assert.ok(secondPayload.id, 'second payload should include id field');
+
+  assert.notEqual(firstPayload.id, secondPayload.id, 'streamed events should have unique ids');
+});

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -10,7 +10,8 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def run_node_tests() -> None:
-    subprocess.run(["node", "--test", "tests/test_ws_demo_server_js.js"], check=True, cwd=ROOT)
+    js_tests = sorted(str(file_path.relative_to(ROOT)) for file_path in (ROOT / "tests").glob("*.js"))
+    subprocess.run(["node", "--test", *js_tests], check=True, cwd=ROOT)
 
 
 def run_py_tests() -> None:


### PR DESCRIPTION
## Summary
- inject TerraBrand font variables and global styling into the app layout
- update the live dashboard wrapper to rely on the new TerraBrand font stack
- add integration tests covering TerraBrand usage, CSV ingestion, and WebSocket streaming, and expand the test runner to execute all JS tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_689a7b25945883309ed227788bf6e438